### PR TITLE
UL-798 Fix bug: Return "control" if the client isn't ready instead of…

### DIFF
--- a/src/main/java/io/unlaunch/DefaultUnlaunchClient.java
+++ b/src/main/java/io/unlaunch/DefaultUnlaunchClient.java
@@ -87,6 +87,11 @@ final class DefaultUnlaunchClient implements UnlaunchClient {
             return UnlaunchConstants.getControlFeatureByName(flagKey);
         }
 
+        if (!isReady()) {
+            logger.warn("the SDK is not ready. Returning the SDK default 'control' as variation which may not give the right result");
+            return UnlaunchConstants.getControlFeatureByName(flagKey);
+        }
+
         UnlaunchUser user;
         if (attributes == null) {
             user = UnlaunchUser.create(identity);

--- a/src/main/java/io/unlaunch/utils/UnlaunchConstants.java
+++ b/src/main/java/io/unlaunch/utils/UnlaunchConstants.java
@@ -18,14 +18,14 @@ public class UnlaunchConstants {
     public static final String FLAG_DEFAULT_RETURN_TYPE = "control";
 
     public static final UnlaunchFeature getControlFeatureByName(String flagKey) {
-        return UnlaunchFeature.create(flagKey, "", null,
+        return UnlaunchFeature.create(flagKey, FLAG_DEFAULT_RETURN_TYPE, null,
                 "Unable to retrieve feature. Returning control variation" );
     }
 
     public static final String getSdkKeyHelpMessage() {
-        return "To obtain the SDK key for your project, please sign in to the Unlaunch Console at " +
-                "https://app.unlaunch.io  Then on the right sidebar, click on 'Settings'. From the 'Projects' tab, " +
-                "Copy the 'SERVER_KEY' for the environment you want to connect to, and provide it to this SDK. For " +
-                "more information, see this: https://docs.unlaunch.io/docs/sdks/sdk-keys";
+        return "To obtain the API key, please sign in to the Unlaunch Console at " +
+                "https://app.unlaunch.io  Then on the right sidebar, click on 'Settings'. Then from the 'Projects' " +
+                "tab, Copy the 'SERVER KEY' for the environment you want to connect to, and provide it to this SDK. " +
+                "For more information, visit: https://docs.unlaunch.io/docs/sdks/sdk-keys";
     }
 }

--- a/src/test/java/io/unlaunch/DefaultUnlaunchClientTest.java
+++ b/src/test/java/io/unlaunch/DefaultUnlaunchClientTest.java
@@ -58,7 +58,7 @@ public class DefaultUnlaunchClientTest {
     @Test
     public void tesWhenFlagIsDisabledAndOffVariationIsServed() {
         DefaultUnlaunchClient client = DefaultUnlaunchClient.create(refreshableDataStoreProvider.getDataStore(),
-                eventHandler, flagInvocationMetricHandler, impressionsEventHandler, downLatch, atomicBoolean,
+                eventHandler, flagInvocationMetricHandler, impressionsEventHandler, downLatch, new AtomicBoolean(true),
                 Boolean.TRUE::booleanValue);
 
         final String flagKey = "flag123";
@@ -82,6 +82,7 @@ public class DefaultUnlaunchClientTest {
 
         when(unlaunchHttpDataStore.getFlag(any())).thenReturn(null);
 
+
         Assert.assertEquals(UnlaunchConstants.FLAG_DEFAULT_RETURN_TYPE, client.getVariation("unknownflag",
                 UUID.randomUUID().toString()));
 
@@ -102,8 +103,9 @@ public class DefaultUnlaunchClientTest {
     @Test
     public void testFlagWhenFlagIsDisabledAndOffVariationIsServed() {
         DefaultUnlaunchClient client = DefaultUnlaunchClient.create(refreshableDataStoreProvider.getDataStore(),
-                eventHandler, flagInvocationMetricHandler, impressionsEventHandler, downLatch, atomicBoolean,
+                eventHandler, flagInvocationMetricHandler, impressionsEventHandler, downLatch, new AtomicBoolean(true),
                 Boolean.TRUE::booleanValue);
+
 
         final String flagKey = "flag123";
 
@@ -116,6 +118,7 @@ public class DefaultUnlaunchClientTest {
         final String VALUE ="RESULT";
         when(variation.getKey()).thenReturn(VALUE);
         when(flag.getOffVariation()).thenReturn(variation);
+
 
         final String result = client.getVariation(flagKey, UUID.randomUUID().toString());
         Assert.assertEquals(VALUE, result);
@@ -178,10 +181,10 @@ public class DefaultUnlaunchClientTest {
 
         // After shutdown, the variation that's returned must be empty string
         v = client.getVariation(flagKey, UUID.randomUUID().toString());
-        Assert.assertTrue(v.isEmpty());
+        Assert.assertEquals(UnlaunchConstants.FLAG_DEFAULT_RETURN_TYPE, v);
 
        UnlaunchFeature f = client.getFeature(flagKey, UUID.randomUUID().toString());
-        Assert.assertTrue(v.isEmpty());
+        Assert.assertEquals(UnlaunchConstants.FLAG_DEFAULT_RETURN_TYPE, v);
     }
 
     @Test


### PR DESCRIPTION
… empty string