### PR TITLE
UL-777 add set unit tests

### DIFF
--- a/src/main/java/io/unlaunch/UnlaunchFeature.java
+++ b/src/main/java/io/unlaunch/UnlaunchFeature.java
@@ -67,6 +67,9 @@ public class UnlaunchFeature {
      * @return  {@link Map} of Key-Value configuration for the evaluated variation.
      */
     public Map<String, String> getVariationConfigAsMap() {
+        if (properties == null || properties.isEmpty()) {
+            return new HashMap<>();
+        }
         return new HashMap<>(properties);
     }
 
@@ -77,6 +80,9 @@ public class UnlaunchFeature {
      * @return  {@link UnlaunchDynamicConfig} for configuration (Key-Value)
      */
     public UnlaunchDynamicConfig getVariationConfig() {
+        if (properties == null || properties.isEmpty()) {
+            new DefaultUnlaunchDynamicConfig(null);
+        }
         return new DefaultUnlaunchDynamicConfig(Collections.unmodifiableMap(properties));
     }
 
@@ -104,6 +110,4 @@ public class UnlaunchFeature {
     public static UnlaunchFeature create(String flagKey, String variationKey, Map<String, String> properties) {
         return new UnlaunchFeature(flagKey, variationKey, "", properties);
     }
-
-
 }

--- a/src/test/java/io/unlaunch/engine/SetAttributeTest.java
+++ b/src/test/java/io/unlaunch/engine/SetAttributeTest.java
@@ -116,6 +116,65 @@ public class SetAttributeTest {
         OffVariation();
     }
 
+    // Not All Of
+    @Test
+    public void Not_All_Of_EqualSets_ShouldNotMatch() {
+        Set<String> userSet = new HashSet();
+        userSet.add("user1");
+        userSet.add("user2");
+
+        List<String> values = new ArrayList<>();
+        values.add("user2");
+        values.add("user1");
+
+        setCondition(Operator.DOES_NOT_HAVE_ALL_OF, userSet, values);
+
+        OffVariation();
+    }
+
+    @Test
+    public void Not_All_Of_UserSetIsSuperset_ShouldNotMatch() {
+        Set<String> userSet = new HashSet();
+        userSet.add("user3");
+        userSet.add("user1");
+        userSet.add("user2");
+
+        List<String> values = new ArrayList<>();
+        values.add("user2");
+        values.add("user1");
+
+        setCondition(Operator.DOES_NOT_HAVE_ALL_OF, userSet, values);
+
+        OffVariation();
+    }
+
+    @Test
+    public void Not_All_Of_WhenUserSetIsSubset_ShouldMatch() {
+        Set<String> userSet = new HashSet();
+        userSet.add("user2");
+
+        List<String> values = new ArrayList<>();
+        values.add("user2");
+        values.add("user1");
+
+        setCondition(Operator.DOES_NOT_HAVE_ALL_OF, userSet, values);
+
+        OnVariation();
+    }
+
+    @Test
+    public void Not_All_Of_WhenUserSetIsEmpty_ShouldMatch() {
+        Set<String> userSet = new HashSet();
+
+        List<String> values = new ArrayList<>();
+        values.add("user2");
+        values.add("user1");
+
+        setCondition(Operator.DOES_NOT_HAVE_ALL_OF, userSet, values);
+
+        OnVariation();
+    }
+
     // Any Of
     @Test
     public void Any_Of_EqualSets_ShouldMatch() {
@@ -209,6 +268,99 @@ public class SetAttributeTest {
         OffVariation();
     }
 
+    // Not Any Of
+    @Test
+    public void Not_Any_Of_EqualSets_ShouldNotMatch() {
+        Set<String> userSet = new HashSet();
+        userSet.add("1");
+        userSet.add("2");
+
+        List<String> values = new ArrayList<>();
+        values.add("1");
+        values.add("2");
+
+        setCondition(Operator.DOES_NOT_HAVE_ANY_OF, userSet, values);
+
+        OffVariation();
+    }
+
+    @Test
+    public void Not_Any_Of_UserSetIsSuperset_ShouldNotMatch() {
+        Set<String> userSet = new HashSet();
+        userSet.add("1");
+        userSet.add("3");
+        userSet.add("2");
+
+        List<String> values = new ArrayList<>();
+        values.add("1");
+        values.add("2");
+
+        setCondition(Operator.DOES_NOT_HAVE_ANY_OF, userSet, values);
+
+        OffVariation();
+    }
+
+    @Test
+    public void Not_Any_Of_UserSetIsSubSet_ShouldNotMatch() {
+        Set<String> userSet = new HashSet();
+        userSet.add("2");
+
+        List<String> values = new ArrayList<>();
+        values.add("1");
+        values.add("2");
+
+        setCondition(Operator.DOES_NOT_HAVE_ANY_OF, userSet, values);
+
+        OffVariation();
+    }
+
+    @Test
+    public void Not_Any_Of_UserSetIsSubSetUnordered_ShouldNotMatch() {
+        Set<String> userSet = new HashSet();
+        userSet.add("1");
+        userSet.add("2");
+        userSet.add("3");
+        userSet.add("4");
+
+        List<String> values = new ArrayList<>();
+        values.add("3");
+        values.add("2");
+        values.add("1");
+        values.add("10");
+
+        setCondition(Operator.DOES_NOT_HAVE_ANY_OF, userSet, values);
+
+        OffVariation();
+    }
+
+    @Test
+    public void Not_Any_Of_UserSetIsDisjoint_ShouldMatch() {
+        Set<String> userSet = new HashSet();
+        userSet.add("4");
+        userSet.add("5");
+
+        List<String> values = new ArrayList<>();
+        values.add("1");
+        values.add("2");
+        values.add("3");
+
+        setCondition(Operator.DOES_NOT_HAVE_ANY_OF, userSet, values);
+
+        OnVariation();
+    }
+
+    @Test
+    public void Not_Any_Of_UserSetIsEmpty_ShouldMatch() {
+        Set<String> userSet = new HashSet();
+
+        List<String> values = new ArrayList<>();
+        values.add("1");
+
+        setCondition(Operator.DOES_NOT_HAVE_ANY_OF, userSet, values);
+
+        OnVariation();
+    }
+
     // Part Of
     @Test
     public void Part_Of_WhenEqualSets_ShouldMatch() {
@@ -255,6 +407,54 @@ public class SetAttributeTest {
         setCondition(Operator.IS_PART_OF, userSet, values);
 
         OnVariation();
+    }
+
+    // Not Part Of
+    @Test
+    public void Not_Part_Of_WhenEqualSets_ShouldNotMatch() {
+        Set<String> userSet = new HashSet();
+        userSet.add("1");
+        userSet.add("2");
+
+        List<String> values = new ArrayList<>();
+        values.add("2");
+        values.add("1");
+
+        setCondition(Operator.IS_NOT_PART_OF, userSet, values);
+
+        OffVariation();
+    }
+
+    @Test
+    public void Not_Part_Of_WhenUserSetIsSuperset_ShouldMatch() {
+        Set<String> userSet = new HashSet();
+        userSet.add("1");
+        userSet.add("2");
+        userSet.add("3");
+
+        List<String> values = new ArrayList<>();
+        values.add("2");
+        values.add("1");
+
+        setCondition(Operator.IS_NOT_PART_OF, userSet, values);
+
+        OffVariation();
+    }
+
+    @Test
+    public void Not_Part_Of_WhenUserSetIsSubset_ShouldNotMatch() {
+        Set<String> userSet = new HashSet();
+        userSet.add("1");
+        userSet.add("2");
+
+        List<String> values = new ArrayList<>();
+        values.add("2");
+        values.add("1");
+        values.add("3");
+
+        setCondition(Operator.IS_NOT_PART_OF, userSet, values);
+
+        OffVariation();
     }
 
     // Equals


### PR DESCRIPTION
I just remember that java-sdk is doing set operator differently, so adding more tests.

Suppose in GO sdk, we do PartOf, and for Not Part Of we just do: !PartOf(), but java-sdk doesn't do that.