### PR TITLE
Disable impression events

### DIFF
--- a/src/main/java/io/unlaunch/DefaultUnlaunchClient.java
+++ b/src/main/java/io/unlaunch/DefaultUnlaunchClient.java
@@ -1,6 +1,5 @@
 package io.unlaunch;
 
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -170,7 +169,7 @@ final class DefaultUnlaunchClient implements UnlaunchClient {
     }
 
     /**
-     * Close everything by calling close on providerss.
+     * Close everything by calling close on providers.
      *
      */
     @Override

--- a/src/main/java/io/unlaunch/DefaultUnlaunchClientBuilder.java
+++ b/src/main/java/io/unlaunch/DefaultUnlaunchClientBuilder.java
@@ -230,6 +230,7 @@ final class DefaultUnlaunchClientBuilder implements UnlaunchClientBuilder {
                 UnlaunchRestWrapper.create(sdkKey, host, eventApiPath, connectionTimeoutMs, readTimeoutMs);
         EventHandler eventHandler = EventHandler.createGenericEventHandler(
                 "generic",
+                true,
                 eventsApiRestClient,
                 eventFlushIntervalInSeconds,
                 eventsQueueSize);
@@ -239,6 +240,7 @@ final class DefaultUnlaunchClientBuilder implements UnlaunchClientBuilder {
         EventHandler impressionsEventHandler =
                 EventHandler.createGenericEventHandler(
                 "metrics-impressions",
+                false,
                 impressionApiRestClient,
                 metricsFlushInterval,
                     metricsQueueSize);

--- a/src/main/java/io/unlaunch/event/AbstractEventHandler.java
+++ b/src/main/java/io/unlaunch/event/AbstractEventHandler.java
@@ -30,13 +30,15 @@ abstract class AbstractEventHandler implements EventHandler {
     private final AtomicBoolean closed = new AtomicBoolean(false);
     private final ScheduledExecutorService flushExecutor;
     private final String name;
+    private final boolean enabled;
     private final int maxBufferSize;
     private AtomicLong lastFlushInMillis = new AtomicLong();
     private static final Logger logger = LoggerFactory.getLogger(AbstractEventHandler.class);
 
-    AbstractEventHandler(String name, UnlaunchRestWrapper restClient, long flushIntervalInSeconds, int maxBufferSize) {
+    AbstractEventHandler(String name, boolean enabled, UnlaunchRestWrapper restClient, long flushIntervalInSeconds, int maxBufferSize) {
         this.restClient = restClient;
         this.name = name;
+        this.enabled = enabled;
         this.maxBufferSize = maxBufferSize;
         flushExecutor = Executors.newScheduledThreadPool(1,
                 new ThreadFactoryBuilder().setNameFormat(name + "-flush" + "-%d").build());
@@ -46,7 +48,7 @@ abstract class AbstractEventHandler implements EventHandler {
 
     @Override
     public boolean handle(Event event) {
-        if (event == null || closed.get()) {
+        if (!enabled || event == null || closed.get()) {
             return false;
         }
 

--- a/src/main/java/io/unlaunch/event/EventHandler.java
+++ b/src/main/java/io/unlaunch/event/EventHandler.java
@@ -18,15 +18,14 @@ public interface EventHandler extends Closeable {
 
     void close();
 
-    static GenericEventHandler createGenericEventHandler(String name, UnlaunchRestWrapper unlaunchRestWrapper,
+    static GenericEventHandler createGenericEventHandler(String name, boolean enabled, UnlaunchRestWrapper unlaunchRestWrapper,
                                                          long eventFlushIntervalInSeconds) {
-        return new GenericEventHandler(name, unlaunchRestWrapper, eventFlushIntervalInSeconds, 100);
+        return new GenericEventHandler(name, enabled, unlaunchRestWrapper, eventFlushIntervalInSeconds, 100);
     }
 
-    static GenericEventHandler createGenericEventHandler(String name, UnlaunchRestWrapper unlaunchRestWrapper,
+    static GenericEventHandler createGenericEventHandler(String name, boolean enabled, UnlaunchRestWrapper unlaunchRestWrapper,
                                                          long eventFlushIntervalInSeconds, int maxBufferSize) {
-        return new GenericEventHandler(name, unlaunchRestWrapper, eventFlushIntervalInSeconds,
-                maxBufferSize);
+        return new GenericEventHandler(name, enabled, unlaunchRestWrapper, eventFlushIntervalInSeconds, maxBufferSize);
     }
 
     static CountAggregatorEventHandler createCountAggregatorEventHandler(EventHandler eventHandler, long runFrequency, TimeUnit unit) {

--- a/src/main/java/io/unlaunch/event/GenericEventHandler.java
+++ b/src/main/java/io/unlaunch/event/GenericEventHandler.java
@@ -17,9 +17,9 @@ final class GenericEventHandler extends AbstractEventHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(GenericEventHandler.class);
 
-    GenericEventHandler(String name, UnlaunchRestWrapper restClientForEventsApi, long eventFlushIntervalInSeconds,
-                        int maxBufferSize) {
-        super(name, restClientForEventsApi, eventFlushIntervalInSeconds, maxBufferSize);
+    GenericEventHandler(String name, boolean enabled, UnlaunchRestWrapper
+            restClientForEventsApi, long eventFlushIntervalInSeconds, int maxBufferSize) {
+        super(name, enabled, restClientForEventsApi, eventFlushIntervalInSeconds, maxBufferSize);
     }
 
 }

--- a/src/test/java/io/unlaunch/GenericEventHandlerTest.java
+++ b/src/test/java/io/unlaunch/GenericEventHandlerTest.java
@@ -19,7 +19,7 @@ public class GenericEventHandlerTest {
     public void testEventIsNull() {
         UnlaunchRestWrapper unlaunchRestWrapper =
                 UnlaunchRestWrapper.create("blah", "blah", "blah", 1000, 1000);
-        EventHandler eventHandler = EventHandler.createGenericEventHandler("evt", unlaunchRestWrapper,1000);
+        EventHandler eventHandler = EventHandler.createGenericEventHandler("evt", true, unlaunchRestWrapper,1000);
         boolean res = eventHandler.handle(null);
         Assert.assertFalse(res);
         eventHandler.close();
@@ -29,7 +29,7 @@ public class GenericEventHandlerTest {
     public void testEventsRejectedAfterClosed() {
         UnlaunchRestWrapper unlaunchRestWrapper =
                 UnlaunchRestWrapper.create("blah", "blah", "blah", 1000, 1000);
-        EventHandler eventHandler =EventHandler.createGenericEventHandler("evt", unlaunchRestWrapper, 1000);
+        EventHandler eventHandler =EventHandler.createGenericEventHandler("evt", true, unlaunchRestWrapper, 1000);
         eventHandler.close();
         boolean res = eventHandler.handle(new Event("blah", ""));
         Assert.assertFalse(res);
@@ -39,7 +39,7 @@ public class GenericEventHandlerTest {
     public void testEventsAreNotSentUntilMaxSizeIsReached() {
         UnlaunchRestWrapper unlaunchRestWrapper = Mockito.mock(UnlaunchRestWrapper.class);
 
-        EventHandler eventHandler = EventHandler.createGenericEventHandler("evt", unlaunchRestWrapper,
+        EventHandler eventHandler = EventHandler.createGenericEventHandler("evt", true, unlaunchRestWrapper,
                 Long.MAX_VALUE,
                 Integer.MAX_VALUE);
 
@@ -55,7 +55,7 @@ public class GenericEventHandlerTest {
     public void testEventsAreSentOutImmediatelyOnFlush()  {
         UnlaunchRestWrapper unlaunchRestWrapper = Mockito.mock(UnlaunchRestWrapper.class);
 
-        EventHandler eventHandler = EventHandler.createGenericEventHandler("evt", unlaunchRestWrapper,
+        EventHandler eventHandler = EventHandler.createGenericEventHandler("evt", true, unlaunchRestWrapper,
                 Long.MAX_VALUE,
                 Integer.MAX_VALUE);
 
@@ -73,7 +73,7 @@ public class GenericEventHandlerTest {
         UnlaunchRestWrapper unlaunchRestWrapper = Mockito.mock(UnlaunchRestWrapper.class);
 
         final int bufferSize = 3;
-        EventHandler eventHandler = EventHandler.createGenericEventHandler("evt", unlaunchRestWrapper,
+        EventHandler eventHandler = EventHandler.createGenericEventHandler("evt", true, unlaunchRestWrapper,
                 Long.MAX_VALUE,
                 bufferSize);
 
@@ -96,6 +96,7 @@ public class GenericEventHandlerTest {
         final int flushIntervalInSeconds = 1;
         EventHandler eventHandler = EventHandler.createGenericEventHandler(
                 "evt",
+                true,
                 eventsApiRestClient,
                 flushIntervalInSeconds,
                 Integer.MAX_VALUE);


### PR DESCRIPTION
Currently leave Builder as it is, where users can adjust metricQueue size or metric flush interval. We would need to update our documentation not showing those.